### PR TITLE
Add environment handler and personality to agent

### DIFF
--- a/internal/clients/team7/agents/EnvironmentHandler.go
+++ b/internal/clients/team7/agents/EnvironmentHandler.go
@@ -1,0 +1,41 @@
+package agents
+
+import (
+	objects "SOMAS2023/internal/common/objects"
+	utils "SOMAS2023/internal/common/utils"
+
+	"github.com/google/uuid"
+)
+
+type EnvironmentHandler struct {
+	GameState     objects.IGameState // Game state to be updated in each round
+	CurrentBikeId uuid.UUID          // unique ID of current bike
+}
+
+func (env *EnvironmentHandler) GetLootBoxesByColour(colour utils.Colour) []objects.ILootBox {
+	lootBoxes := env.GameState.GetLootBoxes()
+	var matchingLootBoxes []objects.ILootBox
+	for _, lootBox := range lootBoxes {
+		if lootBox.GetColour() == colour {
+			matchingLootBoxes = append(matchingLootBoxes, lootBox)
+		}
+	}
+	return matchingLootBoxes
+}
+
+func (env *EnvironmentHandler) GetAgentsOnCurrentBike() []objects.IBaseBiker {
+	return env.GetBikeAgentsByBikeId(env.CurrentBikeId)
+}
+
+func (env *EnvironmentHandler) GetBikeAgentsByBikeId(bikeId uuid.UUID) []objects.IBaseBiker {
+	megaBikes := env.GameState.GetMegaBikes()
+	bike := megaBikes[bikeId]
+	return bike.GetAgents()
+}
+
+func NewEnvironmentHandler(gameState objects.IGameState, bikeId uuid.UUID) *EnvironmentHandler {
+	return &EnvironmentHandler{
+		GameState:     gameState,
+		CurrentBikeId: bikeId,
+	}
+}

--- a/internal/clients/team7/agents/Personality.go
+++ b/internal/clients/team7/agents/Personality.go
@@ -1,0 +1,24 @@
+package agents
+
+/*
+  A personality is a set of traits that define how an agent behaves. These traits can
+  be used to modulate and control how agents make decisions, and how they perceive and
+  interact with other agents.
+*/
+type Personality struct {
+	SelfConfidence    float64 // Measure of self-confidence
+	Compassion        float64 // Measure of compassion which modulates decisions
+	PositiveTrustStep float64 // Rate at which trust is gained
+	NegativeTrustStep float64 // Rate at which trust is lost
+	Trustworthiness   float64 // Measure of trustworthiness to control truth and lies
+}
+
+func NewDefaultPersonality() *Personality {
+	return &Personality{
+		SelfConfidence:    1,   // Confident in own decisions
+		Compassion:        0.5, // Neutral compassion
+		PositiveTrustStep: 0.1, // Trust is gained slowly
+		NegativeTrustStep: 0.1, // Trust is lost slowly
+		Trustworthiness:   1,   // Will never lie
+	}
+}

--- a/internal/clients/team7/agents/TeamSevenBiker.go
+++ b/internal/clients/team7/agents/TeamSevenBiker.go
@@ -19,17 +19,22 @@ type BaseTeamSevenBiker struct {
 	opinionFramework      *frameworks.OpinionFramework
 	socialNetwork         *frameworks.SocialNetwork
 	votingFramework       *frameworks.VotingFramework
+	environmentHandler    *EnvironmentHandler
+	personality           *Personality
 }
 
 // Produce new BaseTeamSevenBiker
 func NewBaseTeamSevenBiker(agentId uuid.UUID) *BaseTeamSevenBiker {
+	baseBiker := objects.GetBaseBiker(utils.GenerateRandomColour(), agentId)
 	return &BaseTeamSevenBiker{
-		BaseBiker:             objects.GetBaseBiker(utils.GenerateRandomColour(), agentId),
+		BaseBiker:             baseBiker,
 		navigationFramework:   frameworks.NewNavigationDecisionFramework(),
 		bikeDecisionFramework: frameworks.NewBikeDecisionFramework(),
 		opinionFramework:      frameworks.NewOpinionFramework(frameworks.OpinionFrameworkInputs{}),
 		socialNetwork:         frameworks.NewSocialNetwork(),
 		votingFramework:       frameworks.NewVotingFramework(),
+		environmentHandler:    NewEnvironmentHandler(baseBiker.GetGameState(), baseBiker.GetMegaBikeId()),
+		personality:           NewDefaultPersonality(),
 	}
 }
 

--- a/internal/common/objects/BaseBiker.go
+++ b/internal/common/objects/BaseBiker.go
@@ -241,3 +241,11 @@ func (bb *BaseBiker) SetGameState(gameState IGameState) {
 func (bb *BaseBiker) SetAllocationParams(allocationParams ResourceAllocationParams) {
 	bb.allocationParams = allocationParams
 }
+
+func (bb *BaseBiker) GetGameState() IGameState {
+	return bb.gameState
+}
+
+func (bb *BaseBiker) GetMegaBikeId() uuid.UUID {
+	return bb.megaBikeId
+}


### PR DESCRIPTION
This change adds the following to the agent

### EnvironmentHandler
Used to abstract interactions with the environment, currently through the IGameState interface. More functions can be added as needed but I've added some examples which I imagine we'd use.

### Personality
This class can influence how our agent makes decisions and perceives the world around it. Added a few default traits but more can be added as we go along.