### PR TITLE
Update social network and trust calculations

### DIFF
--- a/internal/clients/team7/agents/TeamSevenBiker.go
+++ b/internal/clients/team7/agents/TeamSevenBiker.go
@@ -4,6 +4,7 @@ import (
 	"SOMAS2023/internal/clients/team7/frameworks"
 	objects "SOMAS2023/internal/common/objects"
 	"SOMAS2023/internal/common/utils"
+	"SOMAS2023/internal/common/voting"
 
 	"github.com/google/uuid"
 )
@@ -21,47 +22,72 @@ type BaseTeamSevenBiker struct {
 	votingFramework       *frameworks.VotingFramework
 	environmentHandler    *frameworks.EnvironmentHandler
 	personality           *frameworks.Personality
+
+	previousProposedTurningDirection float64
 }
 
 // Produce new BaseTeamSevenBiker
 func NewBaseTeamSevenBiker(agentId uuid.UUID) *BaseTeamSevenBiker {
 	baseBiker := objects.GetBaseBiker(utils.GenerateRandomColour(), agentId)
+	personality := frameworks.NewDefaultPersonality()
 	return &BaseTeamSevenBiker{
 		BaseBiker:             baseBiker,
 		navigationFramework:   frameworks.NewNavigationDecisionFramework(),
 		bikeDecisionFramework: frameworks.NewBikeDecisionFramework(),
 		opinionFramework:      frameworks.NewOpinionFramework(frameworks.OpinionFrameworkInputs{}),
-		socialNetwork:         frameworks.NewSocialNetwork(),
+		socialNetwork:         frameworks.NewSocialNetwork(personality),
 		votingFramework:       frameworks.NewVotingFramework(),
+		personality:           personality,
 		environmentHandler:    frameworks.NewEnvironmentHandler(baseBiker.GetGameState(), baseBiker.GetMegaBikeId(), agentId),
-		personality:           frameworks.NewDefaultPersonality(),
 	}
 }
 
 // Override base biker functions
 func (biker *BaseTeamSevenBiker) DecideForce(direction uuid.UUID) {
+	// Store previous proposed direction for next round's decisions
+
+	proposedLootbox := biker.environmentHandler.GetLootboxById(direction)
+
 	navInputs := frameworks.NavigationInputs{
-		DesiredLootbox:  biker.environmentHandler.GetNearestLootBox().GetPosition(),
+		Destination:     proposedLootbox.GetPosition(),
 		CurrentLocation: biker.GetLocation(),
 	}
+
+	biker.previousProposedTurningDirection = biker.navigationFramework.GetTurnAngle(navInputs)
+
 	navOutput := biker.navigationFramework.GetDecision(navInputs)
 
 	biker.SetForces(navOutput)
 }
 
-/*
-// Ally will update this as soon as the infrastructure is merged!
+// Override UpdateAgentInternalState
+func (biker *BaseTeamSevenBiker) UpdateAgentInternalState() {
+	biker.BaseBiker.UpdateAgentInternalState()
 
-// VOTING FUNCTIONS
-func (biker *BaseTeamSevenBiker) DecideJoining(pendingAgents []uuid.UUID) map[uuid.UUID]bool {
-	voteInputs := frameworks.VoteInputs{
-		DecisionType:   frameworks.VoteToAcceptNewAgent,
-		Candidates:     pendingAgents,
-		VoteParameters: frameworks.YesNo,
+	fellowBikers := biker.environmentHandler.GetAgentsOnCurrentBike()
+
+	agentForces := make(map[uuid.UUID]utils.Forces)
+	agentColours := make(map[uuid.UUID]utils.Colour)
+	agentEnergyLevels := make(map[uuid.UUID]float64)
+	agentResourceVotes := make(map[uuid.UUID]voting.IdVoteMap)
+
+	agentIds := make([]uuid.UUID, len(fellowBikers))
+	for _, fellowBiker := range fellowBikers {
+		agentId := fellowBiker.GetID()
+		agentIds = append(agentIds, agentId)
+		agentForces[agentId] = fellowBiker.GetForces()
+		agentColours[agentId] = fellowBiker.GetColour()
+		agentEnergyLevels[agentId] = fellowBiker.GetEnergyLevel()
+		agentResourceVotes[agentId] = fellowBiker.DecideAllocation()
 	}
 
-	voteOutput := biker.votingFramework.GetDecision(voteInputs)
+	socialNetworkInput := frameworks.SocialNetworkUpdateInput{
+		AgentDecisions:     agentForces,
+		AgentResourceVotes: agentResourceVotes,
+		AgentEnergyLevels:  agentEnergyLevels,
+		AgentColours:       agentColours,
+		BikeTurnAngle:      biker.previousProposedTurningDirection,
+	}
 
-	return voteOutput
+	biker.socialNetwork.UpdateSocialNetwork(agentIds, socialNetworkInput)
 }
-*/

--- a/internal/clients/team7/frameworks/EnvironmentHandler.go
+++ b/internal/clients/team7/frameworks/EnvironmentHandler.go
@@ -25,6 +25,10 @@ func (env *EnvironmentHandler) GetLootBoxesByColour(colour utils.Colour) []objec
 	return matchingLootBoxes
 }
 
+func (env *EnvironmentHandler) GetLootboxById(id uuid.UUID) objects.ILootBox {
+	return env.GameState.GetLootBoxes()[id]
+}
+
 func (env *EnvironmentHandler) GetCurrentBike() objects.IMegaBike {
 	return env.GameState.GetMegaBikes()[env.CurrentBikeId]
 }
@@ -38,6 +42,10 @@ func (env *EnvironmentHandler) GetBikeAgentsByBikeId(bikeId uuid.UUID) []objects
 	bike := megaBikes[bikeId]
 	return bike.GetAgents()
 }
+
+// func (env *EnvironmentHandler) GetBikeLeaderId() uuid.UUID {
+// 	TODO: Implement once we have leaders
+// }
 
 func (env *EnvironmentHandler) GetNearestLootBox() objects.ILootBox {
 	X, Y := env.GetCurrentBike().GetPosition().X, env.GetCurrentBike().GetPosition().Y
@@ -54,20 +62,6 @@ func (env *EnvironmentHandler) GetNearestLootBox() objects.ILootBox {
 	}
 
 	return nearestLootBox
-}
-
-func (env *EnvironmentHandler) GetBikerListByAgentIds(agentIds []uuid.UUID) []objects.IBaseBiker {
-	var bikers []objects.IBaseBiker
-	for _, bike := range env.GameState.GetMegaBikes() {
-		for _, agent := range bike.GetAgents() {
-			for _, agentId := range agentIds {
-				if agentId == agent.GetID() {
-					bikers = append(bikers, agent)
-				}
-			}
-		}
-	}
-	return bikers
 }
 
 func NewEnvironmentHandler(gameState objects.IGameState, bikeId uuid.UUID, agentId uuid.UUID) *EnvironmentHandler {

--- a/internal/clients/team7/frameworks/NavigationDecisionFramework.go
+++ b/internal/clients/team7/frameworks/NavigationDecisionFramework.go
@@ -7,7 +7,7 @@ import (
 )
 
 type NavigationInputs struct {
-	DesiredLootbox  utils.Coordinates
+	Destination     utils.Coordinates
 	CurrentLocation utils.Coordinates
 }
 
@@ -24,26 +24,32 @@ type NavigationDecisionFramework struct {
 
 func (ndf *NavigationDecisionFramework) GetDecision(inputs NavigationInputs) utils.Forces {
 	ndf.inputs = &inputs
-	// Get distances between current location and desired lootbox
-	dx := ndf.inputs.DesiredLootbox.X - ndf.inputs.CurrentLocation.X
-	dy := ndf.inputs.DesiredLootbox.Y - ndf.inputs.CurrentLocation.Y
 
-	angle_radians := math.Atan2(dy, dx)
+	turningForce := ndf.GetTurnAngle(inputs)
+	turningInput := utils.TurningDecision{SteerBike: true, SteeringForce: turningForce}
+	pedallingForce := float64(1)
+	brakingForce := float64(0)
 
-	// Normalize angle to be between -1 and 1
-	turning_force := angle_radians / math.Pi
-	turning_input := utils.TurningDecision{SteerBike: true, SteeringForce: turning_force}
-	pedalling_force := float64(1)
-	braking_force := float64(0)
-
-	forces := utils.Forces{Pedal: pedalling_force, Brake: braking_force, Turning: turning_input}
+	forces := utils.Forces{Pedal: pedallingForce, Brake: brakingForce, Turning: turningInput}
 
 	fmt.Println("NavigationDecisionFramework: GetDecision called")
 	fmt.Println("NavigationDecisionFramework: Current location: ", ndf.inputs.CurrentLocation)
-	fmt.Println("NavigationDecisionFramework: Desired lootbox: ", ndf.inputs.DesiredLootbox)
+	fmt.Println("NavigationDecisionFramework: Desired lootbox: ", ndf.inputs.Destination)
 	fmt.Println("NavigationDecisionFramework: Forces: ", forces)
 
 	return forces
+}
+
+func (ndf *NavigationDecisionFramework) GetTurnAngle(inputs NavigationInputs) float64 {
+	// Get distances between current location and desired lootbox
+	dx := ndf.inputs.Destination.X - ndf.inputs.CurrentLocation.X
+	dy := ndf.inputs.Destination.Y - ndf.inputs.CurrentLocation.Y
+
+	angleRadians := math.Atan2(dy, dx)
+
+	// Normalize angle to be between -1 and 1
+	turningForce := angleRadians / math.Pi
+	return turningForce
 }
 
 func NewNavigationDecisionFramework() *NavigationDecisionFramework {

--- a/internal/clients/team7/frameworks/Personality.go
+++ b/internal/clients/team7/frameworks/Personality.go
@@ -5,20 +5,47 @@ package frameworks
   be used to modulate and control how agents make decisions, and how they perceive and
   interact with other agents.
 */
+import (
+	"math/rand"
+	"time"
+)
+
 type Personality struct {
-	SelfConfidence    float64 // Measure of self-confidence
-	Compassion        float64 // Measure of compassion which modulates decisions
-	PositiveTrustStep float64 // Rate at which trust is gained
-	NegativeTrustStep float64 // Rate at which trust is lost
-	Trustworthiness   float64 // Measure of trustworthiness to control truth and lies
+	SelfConfidence    float64
+	Compassion        float64
+	PositiveTrustStep float64
+	NegativeTrustStep float64
+	Trustworthiness   float64
+	// The following four should add up to 1
+	Egalitarian float64
+	Selfish     float64
+	Judgemental float64
+	Utilitarian float64
 }
 
 func NewDefaultPersonality() *Personality {
-	return &Personality{
-		SelfConfidence:    1,   // Confident in own decisions
-		Compassion:        0.5, // Neutral compassion
-		PositiveTrustStep: 0.1, // Trust is gained slowly
-		NegativeTrustStep: 0.1, // Trust is lost slowly
-		Trustworthiness:   1,   // Will never lie
+	p := &Personality{
+		SelfConfidence:    1,
+		Compassion:        0.5,
+		PositiveTrustStep: 0.1,
+		NegativeTrustStep: 0.1,
+		Trustworthiness:   1,
+	}
+	randomizeTraits(p)
+	return p
+}
+
+func randomizeTraits(p *Personality) {
+	rand.Seed(time.Now().UnixNano())
+	choice := rand.Intn(4)
+	switch choice {
+	case 0:
+		p.Egalitarian = 1
+	case 1:
+		p.Selfish = 1
+	case 2:
+		p.Judgemental = 1
+	case 3:
+		p.Utilitarian = 1
 	}
 }

--- a/internal/clients/team7/frameworks/SocialNetwork.go
+++ b/internal/clients/team7/frameworks/SocialNetwork.go
@@ -2,19 +2,27 @@ package frameworks
 
 import (
 	"SOMAS2023/internal/common/utils"
-	"fmt"
+	voting "SOMAS2023/internal/common/voting"
+	"math"
 
 	"github.com/google/uuid"
 )
 
+const maxTrustIterations int = 6
+
 type SocialConnection struct {
-	connectionAge      int     // Number of rounds the agent has been known
-	trustLevel         float64 // Trust level of the agent, dummy float64 for now.
-	isActiveConnection bool    // Boolean indicating if connection is on current bike
+	connectionAge      int       // Number of rounds the agent has been known
+	trustLevels        []float64 // Trust level of the agent, dummy float64 for now.
+	isActiveConnection bool      // Boolean indicating if connection is on current bike
 }
 
-type SocialConnectionInput struct {
-	agentDecisions map[uuid.UUID]utils.Forces
+type SocialNetworkUpdateInput struct {
+	AgentDecisions     map[uuid.UUID]utils.Forces
+	AgentResourceVotes map[uuid.UUID]voting.IdVoteMap
+	AgentEnergyLevels  map[uuid.UUID]float64
+	AgentColours       map[uuid.UUID]utils.Colour
+	BikeTurnAngle      float64
+	// bikeLeaderId       uuid.UUID
 }
 
 type ISocialNetwork[T any] interface {
@@ -25,58 +33,213 @@ type ISocialNetwork[T any] interface {
 }
 
 type SocialNetwork struct {
-	ISocialNetwork[SocialConnectionInput]
-	socialNetwork *map[uuid.UUID]SocialConnection
+	ISocialNetwork[SocialNetworkUpdateInput]
+	socialNetwork map[uuid.UUID]*SocialConnection
+	personality   *Personality
+	myId          uuid.UUID
 }
 
-func NewSocialNetwork() *SocialNetwork {
+func NewSocialNetwork(personality *Personality) *SocialNetwork {
 	return &SocialNetwork{
-		socialNetwork: &map[uuid.UUID]SocialConnection{},
+		socialNetwork: map[uuid.UUID]*SocialConnection{},
+		personality:   personality,
 	}
 }
 
-func (sn *SocialNetwork) GetSocialNetwork() map[uuid.UUID]SocialConnection {
-	return *sn.socialNetwork
+func (sn *SocialNetwork) GetSocialNetwork() map[uuid.UUID]*SocialConnection {
+	return sn.socialNetwork
 }
 
-func (sn *SocialNetwork) updateTrustLevel(connection *SocialConnection, forces utils.Forces) {
-	// TODO: Update trust level based on forces
-	fmt.Println("SocialNetwork: UpdateTrustLevel called")
-	fmt.Println("SocialNetwork: Current trust level: ", (*connection).trustLevel)
-}
+func (sn *SocialNetwork) updateTrustLevels(input SocialNetworkUpdateInput) {
+	agentIds := make([]uuid.UUID, len(input.AgentDecisions))
+	for agentId := range input.AgentDecisions {
+		if agentId != sn.myId {
+			agentIds = append(agentIds, agentId)
+		}
+	}
 
-func (sn *SocialNetwork) UpdateSocialNetwork(agentIds []uuid.UUID, inputs SocialConnectionInput) {
+	DistancePenaltyMap := sn.CalcDistributionPenalties(input.AgentResourceVotes, input.AgentEnergyLevels)
+	PedallingPenaltyMap := sn.CalcPedallingPenalties(input.AgentDecisions, input.AgentEnergyLevels)
+	OrientationPenaltyMap := sn.CalcTurningPenalties(input.AgentDecisions, input.BikeTurnAngle)
+	BrakingPenaltyMap := sn.CalcBrakingPenalties(input.AgentDecisions)
+	DifferentLootPenaltyMap := sn.CalcDifferentLootBoxPenalties(input.AgentColours)
+
+	W_dp := 1.0
+	W_op := 1.0
+	W_bp := 1.0
+	W_pp := 1.0
+	W_dlp := 1.0
+
 	for _, agentId := range agentIds {
-		connection := (*sn.socialNetwork)[agentId]
-		connection.connectionAge += 1
-		sn.updateTrustLevel(&connection, inputs.agentDecisions[agentId])
-		(*sn.socialNetwork)[agentId] = connection
+		updatedTrust := (W_dp * DistancePenaltyMap[agentId]) +
+			(W_pp * PedallingPenaltyMap[agentId]) +
+			(W_op * OrientationPenaltyMap[agentId]) +
+			(W_bp * BrakingPenaltyMap[agentId]) +
+			(W_dlp * DifferentLootPenaltyMap[agentId])
+
+		trustLevels := sn.socialNetwork[agentId].trustLevels
+		if len(trustLevels) < maxTrustIterations {
+			trustLevels = append(trustLevels, updatedTrust)
+		} else {
+			trustLevels = append(trustLevels[1:], updatedTrust)
+		}
+		sn.socialNetwork[agentId].trustLevels = trustLevels
 	}
 }
 
-func (sn *SocialNetwork) UpdateActiveConnections(agentIds []uuid.UUID) {
-	for _, agentId := range agentIds {
-		connection := (*sn.socialNetwork)[agentId]
-		connection.isActiveConnection = true
-		(*sn.socialNetwork)[agentId] = connection
-	}
+func (sn *SocialNetwork) UpdateSocialNetwork(agentIds []uuid.UUID, inputs SocialNetworkUpdateInput) {
+	sn.updateActiveConnections(agentIds)
+	sn.updateTrustLevels(inputs)
 }
 
-func (sn *SocialNetwork) DeactivateConnections(agentIds []uuid.UUID) {
-	for _, agentId := range agentIds {
-		connection := (*sn.socialNetwork)[agentId]
-		connection.isActiveConnection = false
-		(*sn.socialNetwork)[agentId] = connection
+func (sn *SocialNetwork) updateActiveConnections(agentIds []uuid.UUID) {
+	for agentId, connection := range sn.socialNetwork {
+		agentIsOnBike := false
+		for _, id := range agentIds {
+			if agentId == id {
+				agentIsOnBike = true
+				connection.connectionAge++
+			}
+			continue
+		}
+		connection.isActiveConnection = agentIsOnBike
 	}
 }
 
 // Retrieve agents on the current bike
 func (sn *SocialNetwork) GetCurrentBikeNetwork() map[uuid.UUID]SocialConnection {
 	activeConnections := map[uuid.UUID]SocialConnection{}
-	for agentId, connection := range *sn.socialNetwork {
+	for agentId, connection := range sn.socialNetwork {
 		if connection.isActiveConnection {
-			activeConnections[agentId] = connection
+			activeConnections[agentId] = *connection
 		}
 	}
 	return activeConnections
+}
+
+// Implement individual calculation methods within the SocialNetwork
+
+// Calc_Distribution_penalty calculates the penalty based on resources given
+// and resources requested. This is a method of the SocialNetwork type.
+func (sn *SocialNetwork) CalcDistributionPenalties(resourceDistribution map[uuid.UUID]voting.IdVoteMap, energyLevelMap map[uuid.UUID]float64) map[uuid.UUID]float64 {
+	bikerCount := len(resourceDistribution)
+
+	idPenaltyMap := make(map[uuid.UUID]float64)
+
+	expectedEgalitarianValue := 1.0 / float64(bikerCount)
+	for agentId, agentDistributionVote := range resourceDistribution {
+		utilitarianPenalty := 0.0
+		egalitarianPenalty := 0.0
+		selfishPenalty := 0.0
+		judgementalPenalty := 0.0
+		for recipientId, recipientDistribution := range agentDistributionVote {
+			egalitarianPenalty += math.Abs(expectedEgalitarianValue - recipientDistribution)
+
+			utilitarianPenalty += math.Abs(recipientDistribution - (1 - energyLevelMap[recipientId]))
+
+			if recipientId == sn.myId {
+				selfishPenalty = math.Abs(1 - recipientDistribution)
+			}
+
+			if recipientId == agentId {
+				judgementalPenalty = recipientDistribution
+			}
+		}
+
+		overallPenalty := egalitarianPenalty*sn.personality.Egalitarian +
+			selfishPenalty*sn.personality.Selfish +
+			judgementalPenalty*sn.personality.Judgemental +
+			utilitarianPenalty*sn.personality.Utilitarian
+		idPenaltyMap[agentId] = overallPenalty
+
+	}
+	return idPenaltyMap // Return the calculated penalty map
+}
+
+// TODO: Find shift to account for forgiveness
+func (sn *SocialNetwork) CalcPedallingPenalties(agentForces map[uuid.UUID]utils.Forces, energyLevelMap map[uuid.UUID]float64) map[uuid.UUID]float64 {
+	agentCount := len(agentForces)
+
+	pedallingPenaltyMap := make(map[uuid.UUID]float64)
+
+	totalPedalling := 0.0
+	for _, forces := range agentForces {
+		totalPedalling += forces.Pedal
+	}
+	expectedPedalValue := totalPedalling / float64(agentCount)
+
+	for id, forces := range agentForces {
+		agentPedallingForce := forces.Pedal
+		egalitarianPenalty := math.Abs(expectedPedalValue - agentPedallingForce)
+		utilitarianPenalty := (1-agentPedallingForce)*(energyLevelMap[id]) - (math.Pow(agentPedallingForce, 1.0/agentPedallingForce))*0.3
+		judgementalPenalty := 1 - agentPedallingForce
+		selfishPenalty := 1 - agentPedallingForce
+
+		overallPenalty := egalitarianPenalty*sn.personality.Egalitarian +
+			selfishPenalty*sn.personality.Selfish +
+			judgementalPenalty*sn.personality.Judgemental +
+			utilitarianPenalty*sn.personality.Utilitarian
+
+		pedallingPenaltyMap[id] = overallPenalty
+	}
+
+	return pedallingPenaltyMap
+}
+
+func (sn *SocialNetwork) CalcTurningPenalties(agentForces map[uuid.UUID]utils.Forces, proposedTurnAngle float64) map[uuid.UUID]float64 {
+	turningPenaltyMap := make(map[uuid.UUID]float64)
+
+	for id, forces := range agentForces {
+		turningDecision := forces.Turning
+		// if id == leaderId {
+		// 	if turningDecision.SteerBike && turningDecision.SteeringForce == proposedTurnAngle {
+		// 		turningPenaltyMap[id] = -0.2
+		// 	} else {
+		// 		turningPenaltyMap[id] = 0.3
+		// 	}
+		// 	continue
+		// }
+
+		if turningDecision.SteerBike && turningDecision.SteeringForce == proposedTurnAngle {
+			// Biker is steering in the right direction
+			turningPenaltyMap[id] = -0.2
+		} else if turningDecision.SteerBike && turningDecision.SteeringForce != proposedTurnAngle {
+			// Biker is steering in the wrong direction
+			turningPenaltyMap[id] = 0.5
+		} else {
+			// Biker is not steering
+			turningPenaltyMap[id] = 0.2
+		}
+	}
+
+	return turningPenaltyMap
+}
+
+func (sn *SocialNetwork) CalcBrakingPenalties(agentForces map[uuid.UUID]utils.Forces) map[uuid.UUID]float64 {
+	brakingPenaltyMap := make(map[uuid.UUID]float64)
+	for id, forces := range agentForces {
+		if forces.Brake == 0 {
+			brakingPenaltyMap[id] = 0.8
+			continue
+		}
+	}
+	return brakingPenaltyMap
+}
+
+func (sn *SocialNetwork) CalcDifferentLootBoxPenalties(agentColourMap map[uuid.UUID]utils.Colour) map[uuid.UUID]float64 {
+	myColour := agentColourMap[sn.myId]
+	colourPenaltyMap := make(map[uuid.UUID]float64)
+
+	for _, colour := range agentColourMap {
+		penalty := 0.0
+		if colour == myColour {
+			penalty = -0.2
+		} else {
+			penalty = 0.095
+		}
+		penalty = (1 - sn.personality.Egalitarian) * penalty
+		colourPenaltyMap[sn.myId] = penalty
+	}
+
+	return colourPenaltyMap
 }


### PR DESCRIPTION
Made some big updates to social network and trust calculations.

This builds on some of the work done by @Ahmed22347 and @Laurie2905-JOHN, but I needed to create a new branch because there were weird things happening in the branch used (Trust-Ahmed-LJ) with regards to the merging to main.

Changes:
- Updates to the methods in which trust is updated per agent (calculations are the same as the previous PR made by @Ahmed22347)
- Update in the structure of the inputs to update social network
- Call the functions to update social network within UpdateAgentInternalState

This PR shows how we can get all the information required from the environment and other agents without passing the environment as a whole to the SocialNetwork (or other framework). We should do things in this way as in the future we are not sure what will be available to us. As such this provides an abstraction which allows the biker to get the info in any way possible and then pass it to the frameworks:
Right now:
```
    biker asks env for info
    biker passes info to framework
```
Maybe future:
```
   biker asks other agents for info
   biker passes info to framework
```
