### PR TITLE
Added VoteLeader and VoteDictator files

### DIFF
--- a/internal/clients/team7/agents/TeamSevenBiker.go
+++ b/internal/clients/team7/agents/TeamSevenBiker.go
@@ -201,3 +201,24 @@ func (biker *BaseTeamSevenBiker) DecideKicking(pendingAgents []uuid.UUID) map[uu
 
 	return voteOutput
 }
+
+// Vote on Leader
+// TODO: Uncomment when infrastructure have merged the new voting methods.
+/*
+func (biker *BaseTeamSevenBiker) VoteLeader() voting.IdVoteMap {
+	fellowBikers := biker.environmentHandler.GetAgentsOnCurrentBike()
+
+	agentIds := make([]uuid.UUID, len(fellowBikers))
+	for _, fellowBiker := range fellowBikers {
+		agentIds = append(agentIds, fellowBiker.GetID())
+	}
+
+	voteInputs := frameworks.VoteOnAgentsInput{
+		AgentCandidates: agentIds,
+	}
+	voteHandler := frameworks.NewVoteOnLeaderHandler()
+	voteOutput := voteHandler.GetDecision(voteInputs)
+
+	return voteOutput
+}
+*/

--- a/internal/clients/team7/agents/TeamSevenBiker.go
+++ b/internal/clients/team7/agents/TeamSevenBiker.go
@@ -174,12 +174,7 @@ func (biker *BaseTeamSevenBiker) DecideJoining(pendingAgents []uuid.UUID) map[uu
 
 // Vote on allocation of resources
 func (biker *BaseTeamSevenBiker) DecideAllocation() voting.IdVoteMap {
-	fellowBikers := biker.environmentHandler.GetAgentsOnCurrentBike()
-
-	agentIds := make([]uuid.UUID, len(fellowBikers))
-	for _, fellowBiker := range fellowBikers {
-		agentIds = append(agentIds, fellowBiker.GetID())
-	}
+	agentIds := biker.environmentHandler.GetAgentsOnCurrentBikeId()
 
 	voteInputs := frameworks.VoteOnAllocationInput{
 		AgentCandidates: agentIds,
@@ -206,12 +201,7 @@ func (biker *BaseTeamSevenBiker) DecideKicking(pendingAgents []uuid.UUID) map[uu
 // TODO: Uncomment when infrastructure have merged the new voting methods.
 /*
 func (biker *BaseTeamSevenBiker) VoteLeader() voting.IdVoteMap {
-	fellowBikers := biker.environmentHandler.GetAgentsOnCurrentBike()
-
-	agentIds := make([]uuid.UUID, len(fellowBikers))
-	for _, fellowBiker := range fellowBikers {
-		agentIds = append(agentIds, fellowBiker.GetID())
-	}
+	agentIds := biker.environmentHandler.GetAgentsOnCurrentBikeId()
 
 	voteInputs := frameworks.VoteOnAgentsInput{
 		AgentCandidates: agentIds,

--- a/internal/clients/team7/agents/TeamSevenBiker.go
+++ b/internal/clients/team7/agents/TeamSevenBiker.go
@@ -211,4 +211,17 @@ func (biker *BaseTeamSevenBiker) VoteLeader() voting.IdVoteMap {
 
 	return voteOutput
 }
+
+// Vote on Dictator
+func (biker *BaseTeamSevenBiker) VoteDictator() voting.IdVoteMap {
+	agentIds := biker.environmentHandler.GetAgentsOnCurrentBikeId()
+
+	voteInputs := frameworks.VoteOnAgentsInput{
+		AgentCandidates: agentIds,
+	}
+	voteHandler := frameworks.NewVoteOnDictatorHandler()
+	voteOutput := voteHandler.GetDecision(voteInputs)
+
+	return voteOutput
+}
 */

--- a/internal/clients/team7/frameworks/EnvironmentHandler.go
+++ b/internal/clients/team7/frameworks/EnvironmentHandler.go
@@ -37,6 +37,18 @@ func (env *EnvironmentHandler) GetAgentsOnCurrentBike() []objects.IBaseBiker {
 	return env.GetBikeAgentsByBikeId(env.CurrentBikeId)
 }
 
+// Returns IDs of all agents on bike.
+func (env *EnvironmentHandler) GetAgentsOnCurrentBikeId() []uuid.UUID {
+	fellowBikers := env.GetAgentsOnCurrentBike()
+
+	agentIds := make([]uuid.UUID, len(fellowBikers))
+	for _, fellowBiker := range fellowBikers {
+		agentIds = append(agentIds, fellowBiker.GetID())
+	}
+
+	return agentIds
+}
+
 func (env *EnvironmentHandler) GetBikeAgentsByBikeId(bikeId uuid.UUID) []objects.IBaseBiker {
 	megaBikes := env.GameState.GetMegaBikes()
 	bike := megaBikes[bikeId]

--- a/internal/clients/team7/frameworks/VoteDictator.go
+++ b/internal/clients/team7/frameworks/VoteDictator.go
@@ -1,0 +1,37 @@
+package frameworks
+
+import (
+	voting "SOMAS2023/internal/common/voting"
+)
+
+// This file contains code for voting on the bike Dictator.
+
+type VoteOnDictatorHandler struct {
+	IDecisionFramework[VoteOnAgentsInput, voting.IdVoteMap]
+}
+
+func NewVoteOnDictatorHandler() *VoteOnDictatorHandler {
+	return &VoteOnDictatorHandler{}
+}
+
+func (voteHandler *VoteOnDictatorHandler) GetDecision(inputs VoteOnAgentsInput) voting.IdVoteMap {
+	vote := make(voting.IdVoteMap)
+	agentScoreMap := make(voting.IdVoteMap)
+	totalScore := 0.0
+
+	for _, agent_id := range inputs.AgentCandidates {
+		agentScore := voteHandler.voteOnDictatorScore(agent_id)
+		totalScore += agentScore
+		agentScoreMap[agent_id] = agentScore
+	}
+	// Return a vote map where the sum of the votes is 1, as expected by the environment.
+	vote = NormaliseVote(agentScoreMap, totalScore)
+
+	return vote
+}
+
+// Assign a score to express approval/disapproval of an agent becoming Dictator.
+func (voteHandler *VoteOnDictatorHandler) voteOnDictatorScore(agent_id interface{}) float64 {
+	score := 0.8 //TODO: Simple implementation for now. Will depend on factors such as opinion of agent and our agent's personality.
+	return score
+}

--- a/internal/clients/team7/frameworks/VoteLeader.go
+++ b/internal/clients/team7/frameworks/VoteLeader.go
@@ -1,0 +1,37 @@
+package frameworks
+
+import (
+	voting "SOMAS2023/internal/common/voting"
+)
+
+// This file contains code for voting on the bike leader.
+
+type VoteOnLeaderHandler struct {
+	IDecisionFramework[VoteOnAgentsInput, voting.IdVoteMap]
+}
+
+func NewVoteOnLeaderHandler() *VoteOnLeaderHandler {
+	return &VoteOnLeaderHandler{}
+}
+
+func (voteHandler *VoteOnLeaderHandler) GetDecision(inputs VoteOnAgentsInput) voting.IdVoteMap {
+	vote := make(voting.IdVoteMap)
+	agentScoreMap := make(voting.IdVoteMap)
+	totalScore := 0.0
+
+	for _, agent_id := range inputs.AgentCandidates {
+		agentScore := voteHandler.voteOnLeaderScore(agent_id)
+		totalScore += agentScore
+		agentScoreMap[agent_id] = agentScore
+	}
+	// Return a vote map where the sum of the votes is 1, as expected by the environment.
+	vote = NormaliseVote(agentScoreMap, totalScore)
+
+	return vote
+}
+
+// Assign a score to express approval/disapproval of an agent becoming leader.
+func (voteHandler *VoteOnLeaderHandler) voteOnLeaderScore(agent_id interface{}) float64 {
+	score := 0.8 //TODO: Simple implementation for now. Will depend on factors such as opinion of agent and our agent's personality.
+	return score
+}

--- a/internal/clients/team7/frameworks/VotingFramework.go
+++ b/internal/clients/team7/frameworks/VotingFramework.go
@@ -1,8 +1,9 @@
 package frameworks
 
 import (
+	voting "SOMAS2023/internal/common/voting"
+
 	"github.com/google/uuid"
-	//voting "SOMAS2023/internal/common/voting"
 )
 
 // This map can hold any type of data as the value
@@ -17,4 +18,16 @@ type ScoreType float64
 
 type VoteOnAgentsInput struct {
 	AgentCandidates []uuid.UUID
+}
+
+// Expected to return votes which sum to 1 for some voting types.
+// This function normalises vote map to sum to 1.
+func NormaliseVote(agentScoreMap voting.IdVoteMap, totalScore float64) voting.IdVoteMap {
+	normalisedVoteMap := make(voting.IdVoteMap)
+	// Find the sum of all the scores.
+	for agentId, agentScore := range agentScoreMap {
+		normalisedVoteMap[agentId] = agentScore / totalScore
+	}
+
+	return normalisedVoteMap
 }


### PR DESCRIPTION
Adding two new vote types VoteDictator and VoteLeader in anticipation of infrastructure merging the group8/VotingMethods branch in next few days.

VoteLeader: Basic implementation. Assign a score to each agent on bike. Then normalise the score so that they add up to 1. The NomaliseVote function handles this. Implementation commented out in TeamSevenBiker.go until infrastructure merges.
VoteDictator: Same as VoteLeader for now.
EnvironmentHandler: @btarifi10  could you just double check that the new GetAgentsOnCurrentBikeId method looks ok please? Added it because there are multiple instances where we need a list of the IDs of all agents on our bike. Thanks in advance.